### PR TITLE
ログインユーザーの所属チームに関する情報のみレスポンスで返すようにした

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -27,10 +27,17 @@ class TaskViewSet(viewsets.ModelViewSet):
     serializer_class = TaskSerializer
     authentication_classes = (JWTAuthentication,)
     permission_classes = (IsAuthenticated,)
-
+    
+    def get_queryset(self):
+        user = self.request.user
+        return Task.objects.filter(team_in_charge=user.team_of_affiliation.id)
+    
 class TeamViewSet(viewsets.ModelViewSet):
     queryset = Team.objects.all()
     serializer_class = TeamSerializer
     authentication_classes = (JWTAuthentication,)
     permission_classes = (IsAuthenticated,)
     
+    def get_queryset(self):
+        user = self.request.user
+        return Team.objects.filter(id=user.team_of_affiliation.id)


### PR DESCRIPTION
# 背景
所属チーム以外のチーム情報、及びタスク情報が取得できるべきではないので、ログインユーザーが所属するチームに関する情報のみ一覧のレスポンスで返すようにした

# 内容
- TeamViewSetでget_querysetを定義
- TaskViewSetでget_querysetを定義
