### PR TITLE
所属チームのメンバー一覧表示をコンポーネントに切り出した

### DIFF
--- a/frontend/src/components/Teams/Member.test.tsx
+++ b/frontend/src/components/Teams/Member.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { apiConfig } from 'commons/apiConfig';
+import Member from 'components/Teams/Member';
+
+afterEach(cleanup);
+
+describe('Member', () => {
+  it('Should display member name', async () => {
+    const member_information = {
+      id: 2,
+      username: 'test1',
+      email: 'test1@example.com',
+      team_of_affiliation: 1,
+    };
+    render(<Member user={member_information} />);
+    expect(screen.getByText('test1')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/Teams/Member.test.tsx
+++ b/frontend/src/components/Teams/Member.test.tsx
@@ -5,7 +5,7 @@ import Member from 'components/Teams/Member';
 afterEach(cleanup);
 
 describe('Member', () => {
-  it('Should display member name', async () => {
+  it('Should display member name', () => {
     const member_information = {
       id: 2,
       username: 'test1',

--- a/frontend/src/components/Teams/Member.test.tsx
+++ b/frontend/src/components/Teams/Member.test.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
 import { cleanup, render, screen } from '@testing-library/react';
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { apiConfig } from 'commons/apiConfig';
 import Member from 'components/Teams/Member';
 
 afterEach(cleanup);

--- a/frontend/src/components/Teams/Member.tsx
+++ b/frontend/src/components/Teams/Member.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 
+type User = {
+  id: number;
+  username: string;
+  email: string;
+  team_of_affiliation: number;
+};
+
 type Props = {
-  user: {
-    id: number;
-    username: string;
-    email: string;
-    team_of_affiliation: Number;
-  };
+  user: User;
 };
 
 const Member: React.FC<Props> = ({ user }) => {

--- a/frontend/src/components/Teams/Member.tsx
+++ b/frontend/src/components/Teams/Member.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+type Props = {
+  user: {
+    id: number;
+    username: string;
+    email: string;
+    team_of_affiliation: Number;
+  };
+};
+
+const Member: React.FC<Props> = ({ user }) => {
+  return <li key={user.id}>{user.username}</li>;
+};
+
+export default Member;

--- a/frontend/src/components/Teams/MembersList.test.tsx
+++ b/frontend/src/components/Teams/MembersList.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import MembersList from 'components/Teams/MembersList';
+
+afterEach(cleanup);
+
+describe('MemberList', () => {
+  it('Should display three member', () => {
+    const members_list = [
+      {
+        id: 2,
+        username: 'test1',
+        email: 'test1@example.com',
+        team_of_affiliation: 1,
+      },
+      {
+        id: 5,
+        username: 'test4',
+        email: 'test4@example.com',
+        team_of_affiliation: 1,
+      },
+      {
+        id: 10,
+        username: 'test10',
+        email: 'test10@example.com',
+        team_of_affiliation: 1,
+      },
+    ];
+    render(<MembersList membersInformation={members_list} />);
+    expect(screen.getByText('test1')).toBeTruthy();
+    expect(screen.getByText('test4')).toBeTruthy();
+    expect(screen.getByText('test10')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/Teams/MembersList.tsx
+++ b/frontend/src/components/Teams/MembersList.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Member from 'components/Teams/Member';
+
+type User = {
+  id: number;
+  username: string;
+  email: string;
+  team_of_affiliation: number;
+};
+
+type Props = {
+  membersInformation: User[];
+};
+
+const MembersList: React.FC<Props> = ({ membersInformation }) => {
+  const members = membersInformation.map((member: User) => {
+    return <Member key={member.id} user={member} />;
+  });
+
+  return <ul>{members}</ul>;
+};
+
+export default MembersList;

--- a/frontend/src/pages/Teams.tsx
+++ b/frontend/src/pages/Teams.tsx
@@ -4,20 +4,21 @@ import axios from 'axios';
 import { apiConfig } from 'commons/apiConfig';
 import Auth from 'components/Auth';
 import Title from 'components/Title';
+import MembersList from 'components/Teams/MembersList';
 import './Team.css';
 
 type Team = {
-  id: Number;
+  id: number;
   team_name: string;
   created_at: string;
   updated_at: string;
 };
 
 type User = {
-  id: Number;
+  id: number;
   username: string;
   email: string;
-  team_of_affiliation: Team;
+  team_of_affiliation: number;
 };
 
 const Teams: React.FC = () => {
@@ -46,10 +47,6 @@ const Teams: React.FC = () => {
       });
   }, [baseUrl, cookie]);
 
-  const memberInformation = (member: User) => {
-    return <li>{member.username}</li>;
-  };
-
   if (loading) {
     return (
       <Auth>
@@ -65,15 +62,11 @@ const Teams: React.FC = () => {
       <h3>所属チーム</h3>
       <p>{team ? team.team_name : 'チームに所属していません'}</p>
       <h5>所属メンバー</h5>
-      <ul>
-        {members ? (
-          members.map((member: User) => {
-            return memberInformation(member);
-          })
-        ) : (
-          <li>所属メンバーはいません</li>
-        )}
-      </ul>
+      {members ? (
+        <MembersList membersInformation={members} />
+      ) : (
+        'メンバーはいません'
+      )}
     </Auth>
   );
 };


### PR DESCRIPTION
# 背景
メンバー一覧表示をコンポーネントに切り出して整理した

# 内容
- メンバー情報を表示するMemberコンポーネントとテストを実装
- メンバーを一覧表示するMembersListコンポーネントとテストを実装
- Team画面のメンバー一覧表示をMembersListコンポーネントに置き換えた
