### PR TITLE
unit testのエラーを修正

### DIFF
--- a/frontend/src/components/Teams/InvitationForm.test.tsx
+++ b/frontend/src/components/Teams/InvitationForm.test.tsx
@@ -15,7 +15,7 @@ afterEach(cleanup);
 describe('ApplicationForm', () => {
   it('Should display team name and can click select box', async () => {
     render(<InvitationForm />);
-    expect(screen.findByText('招待')).toBeTruthy();
+    expect(screen.getByText('招待')).toBeTruthy();
   });
 
   // it('Post Invitation', async () => {

--- a/frontend/src/components/Teams/InvitationForm.test.tsx
+++ b/frontend/src/components/Teams/InvitationForm.test.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { cleanup, render, screen } from '@testing-library/react';
-// import userEvent from '@testing-library/user-event';
-// import axios from 'axios';
-// import MockAdapter from 'axios-mock-adapter';
-// import { apiConfig } from 'commons/apiConfig';
+import userEvent from '@testing-library/user-event';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { apiConfig } from 'commons/apiConfig';
 import InvitationForm from 'components/Teams/InvitationForm';
 
-// const baseUrl: string | undefined = apiConfig.apiUrl;
+const baseUrl: string | undefined = apiConfig.apiUrl;
 
-// const mock = new MockAdapter(axios);
+const mock = new MockAdapter(axios);
 
 afterEach(cleanup);
 
@@ -18,12 +18,12 @@ describe('ApplicationForm', () => {
     expect(screen.getByText('招待')).toBeTruthy();
   });
 
-  // it('Post Invitation', async () => {
-  //   mock.onPost(`${baseUrl}invitation_create/`).reply(201);
+  it('Post Invitation', async () => {
+    mock.onPost(`${baseUrl}invitation_create/`).reply(201);
 
-  //   render(<InvitationForm />);
-  //   await userEvent.type(screen.getByRole('textbox'), 'test1@example.com');
-  //   await userEvent.click(screen.getByText('招待'));
-  //   expect(screen.findByText('招待しました')).toBeTruthy();
-  // });
+    render(<InvitationForm />);
+    userEvent.type(screen.getByRole('textbox'), 'test1@example.com');
+    userEvent.click(screen.getByText('招待'));
+    expect(await screen.findByText('招待しました')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
# 概要
findByTextが適切に使用されておらずエラーになっていたため、修正した

# 内容
- テスト1つ目のfindByTextをgetByTextに修正
  - 非同期ではなかった
- 招待した場合の表示を確認するテストを作成
