### PR TITLE
チームを作成する処理を追加

### DIFF
--- a/backend/api/serializers/serializers.py
+++ b/backend/api/serializers/serializers.py
@@ -45,8 +45,9 @@ class MyselfSerializer(serializers.ModelSerializer):
     class Meta:
         model = Users
         fields = ('id', 'username', 'email', 'team_of_affiliation')
-        extra_kwargs = {'password': {'write_only': True, 'required': True}}
     
-    def validate_password(self,value):
-        return make_password(value)
+class MyselfUpdateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Users
+        fields = ('id', 'username', 'email', 'team_of_affiliation')
     

--- a/backend/api/serializers/serializers.py
+++ b/backend/api/serializers/serializers.py
@@ -44,7 +44,7 @@ class MyselfSerializer(serializers.ModelSerializer):
     
     class Meta:
         model = Users
-        fields = ('id', 'username', 'password', 'email', 'team_of_affiliation')
+        fields = ('id', 'username', 'email', 'team_of_affiliation')
         extra_kwargs = {'password': {'write_only': True, 'required': True}}
     
     def validate_password(self,value):

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 from django.conf.urls import include
 from rest_framework import routers
-from api.views import TaskViewSet, TeamViewSet, UserViewSet, ManageUserView, TeamAndTasks, TeamAndMembers, ApplicantsViewSet, ApplicantCreateViewSet, MyApplicationViewSet, InvitationCreateAPIView, MyInvitationDeleteAPIView
+from api.views import TaskViewSet, TeamViewSet, UserViewSet, ManageUserView, MyselfUpdateAPIView, TeamAndTasks, TeamAndMembers, ApplicantsViewSet, ApplicantCreateViewSet, MyApplicationViewSet, InvitationCreateAPIView, MyInvitationDeleteAPIView
 
 router = routers.DefaultRouter()
 router.register('tasks', TaskViewSet)
@@ -13,6 +13,7 @@ router.register('my_application', MyApplicationViewSet)
 
 urlpatterns = [
     path('myself/', ManageUserView.as_view(), name='myself'),
+    path('update_myself/', MyselfUpdateAPIView.as_view(), name='update_myself'),
     path('team_and_tasks/', TeamAndTasks.as_view(), name='team_and_tasks'),
     path('team_and_members/', TeamAndMembers.as_view(), name='team_and_members'),
     path('invitation_create/', InvitationCreateAPIView.as_view(), name='create_invitation'),

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -7,7 +7,7 @@ from users.models import Users
 from .models.task_models import Task
 from .models.team_models import Team
 from .models.application_models import ApplicationToTeam
-from .serializers.serializers import MyselfSerializer, UserSerializer, TaskSerializer, TeamSerializer
+from .serializers.serializers import MyselfSerializer, MyselfUpdateSerializer, UserSerializer, TaskSerializer, TeamSerializer
 from .serializers.application_serializers import ApplicationToTeamSerializer, ApplicationToTeamCreateSerializer
 from .serializers.invitation_create_serializer import InvitationCreateSerializer
 from .ownpermissions import ProfilePermission
@@ -20,6 +20,14 @@ class UserViewSet(mixins.CreateModelMixin, mixins.UpdateModelMixin, mixins.Destr
 
 class ManageUserView(generics.RetrieveUpdateAPIView):
     serializer_class = MyselfSerializer
+    authentication_classes = (JWTAuthentication,)
+    permission_classes = (IsAuthenticated,)
+    
+    def get_object(self):
+        return self.request.user
+
+class MyselfUpdateAPIView(generics.RetrieveUpdateAPIView):
+    serializer_class = MyselfUpdateSerializer
     authentication_classes = (JWTAuthentication,)
     permission_classes = (IsAuthenticated,)
     

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "react-redux": "^7.2.3",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.2",
+    "redux-thunk": "^2.3.0",
     "typescript": "^4.1.2",
     "web-vitals": "^1.0.1"
   },

--- a/frontend/src/constants/constants.ts
+++ b/frontend/src/constants/constants.ts
@@ -1,0 +1,3 @@
+import { apiConfig } from 'commons/apiConfig';
+
+export const baseUrl = apiConfig.apiUrl;

--- a/frontend/src/pages/Teams.tsx
+++ b/frontend/src/pages/Teams.tsx
@@ -109,15 +109,13 @@ const Teams: React.FC = () => {
       }
     );
 
-    console.log('チームを作りました');
-
     await axios.put(
-      `${baseUrl}users/${user.id}/`,
+      `${baseUrl}update_myself/`,
       {
         id: user.id,
         username: user.username,
         email: user.email,
-        team_of_affiliation: res.data,
+        team_of_affiliation: res.data.id,
       },
       {
         headers: {

--- a/frontend/src/pages/Teams.tsx
+++ b/frontend/src/pages/Teams.tsx
@@ -89,7 +89,21 @@ const Teams: React.FC = () => {
   }, [baseUrl, cookie]);
 
   const createNewTeam = async () => {
-    console.log('create new team');
+    axios
+      .post(
+        `${baseUrl}teams/`,
+        {
+          team_name: newTeamName,
+        },
+        {
+          headers: {
+            Authorization: `JWT ${cookie.calendarJWT}`,
+          },
+        }
+      )
+      .then((res) => {
+        console.log('作りました');
+      });
   };
 
   if (loading) {

--- a/frontend/src/pages/Teams.tsx
+++ b/frontend/src/pages/Teams.tsx
@@ -123,8 +123,8 @@ const Teams: React.FC = () => {
         },
       }
     );
-
     dispatch(getMyself(cookie.calendarJWT));
+    setTeam(res.data);
   };
 
   if (loading) {

--- a/frontend/src/slices/user/userSlice.ts
+++ b/frontend/src/slices/user/userSlice.ts
@@ -1,18 +1,43 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from 'axios';
+import { baseUrl } from 'constants/constants';
+
+export const getMyself = createAsyncThunk('user/get', async (token: string) => {
+  const res = await axios.get(`${baseUrl}myself/`, {
+    headers: {
+      Authorization: token,
+    },
+  });
+  return res.data;
+});
+
+type User = {
+  id: string;
+  username: string;
+  email: string;
+  teamOfAffiliation: {
+    id: string;
+    teamName: string;
+    createdAt: string;
+    updatedAt: string;
+  };
+};
+
+const initialState: User = {
+  id: '',
+  username: '',
+  email: '',
+  teamOfAffiliation: {
+    id: '',
+    teamName: '',
+    createdAt: '',
+    updatedAt: '',
+  },
+};
 
 export const userSlice = createSlice({
   name: 'user',
-  initialState: {
-    id: '',
-    username: '',
-    email: '',
-    teamOfAffiliation: {
-      id: '',
-      teamName: '',
-      createdAt: '',
-      updatedAt: '',
-    },
-  },
+  initialState,
   reducers: {
     setMyself: (state, action) => {
       state = action.payload;
@@ -30,6 +55,14 @@ export const userSlice = createSlice({
         },
       };
     },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(getMyself.fulfilled, (state, action) => {
+      return {
+        ...state,
+        users: action.payload,
+      };
+    });
   },
 });
 

--- a/frontend/src/slices/user/userSlice.ts
+++ b/frontend/src/slices/user/userSlice.ts
@@ -11,28 +11,25 @@ export const getMyself = createAsyncThunk('user/get', async (token: string) => {
   return res.data;
 });
 
+type Team = {
+  id: string;
+  teamName: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
 type User = {
   id: string;
   username: string;
   email: string;
-  teamOfAffiliation: {
-    id: string;
-    teamName: string;
-    createdAt: string;
-    updatedAt: string;
-  };
+  team_of_affiliation: Team | null;
 };
 
 const initialState: User = {
   id: '',
   username: '',
   email: '',
-  teamOfAffiliation: {
-    id: '',
-    teamName: '',
-    createdAt: '',
-    updatedAt: '',
-  },
+  team_of_affiliation: null,
 };
 
 export const userSlice = createSlice({
@@ -47,7 +44,7 @@ export const userSlice = createSlice({
         id: '',
         username: '',
         email: '',
-        teamOfAffiliation: {
+        team_of_affiliation: {
           id: '',
           teamName: '',
           createdAt: '',

--- a/frontend/src/slices/user/userSlice.ts
+++ b/frontend/src/slices/user/userSlice.ts
@@ -5,7 +5,7 @@ import { baseUrl } from 'constants/constants';
 export const getMyself = createAsyncThunk('user/get', async (token: string) => {
   const res = await axios.get(`${baseUrl}myself/`, {
     headers: {
-      Authorization: token,
+      Authorization: `JWT ${token}`,
     },
   });
   return res.data;
@@ -60,7 +60,7 @@ export const userSlice = createSlice({
     builder.addCase(getMyself.fulfilled, (state, action) => {
       return {
         ...state,
-        users: action.payload,
+        ...action.payload,
       };
     });
   },


### PR DESCRIPTION
# 概要
実際にチームを作成する処理を追加した

# 詳細
- userSliceにユーザー情報を取得する非同期関数を追加
- TeamのuseEffectにユーザー情報をstoreに追加する処理を追加
- チーム内容をpostする処理をcreateNewTeamに追加
- update_myself/でput用のエンドポイントを追加
- チームpost後にユーザーのteam_of_affiliationをputする処理を追加
- ユーザーのput後にTeam内stateのteamを更新
