### PR TITLE
チーム作成用のフォームを作成

### DIFF
--- a/backend/api/serializers/serializers.py
+++ b/backend/api/serializers/serializers.py
@@ -44,9 +44,10 @@ class MyselfSerializer(serializers.ModelSerializer):
     
     class Meta:
         model = Users
-        fields = ('id', 'username', 'password', 'email', 'team_of_affiliation')
-        extra_kwargs = {'password': {'write_only': True, 'required': True}}
+        fields = ('id', 'username', 'email', 'team_of_affiliation')
     
-    def validate_password(self,value):
-        return make_password(value)
+class MyselfUpdateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Users
+        fields = ('id', 'username', 'email', 'team_of_affiliation')
     

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 from django.conf.urls import include
 from rest_framework import routers
-from api.views import TaskViewSet, TeamViewSet, UserViewSet, ManageUserView, TeamAndTasks, TeamAndMembers, ApplicantsViewSet, ApplicantCreateViewSet, MyApplicationViewSet, InvitationCreateAPIView, MyInvitationDeleteAPIView
+from api.views import TaskViewSet, TeamViewSet, UserViewSet, ManageUserView, MyselfUpdateAPIView, TeamAndTasks, TeamAndMembers, ApplicantsViewSet, ApplicantCreateViewSet, MyApplicationViewSet, InvitationCreateAPIView, MyInvitationDeleteAPIView
 
 router = routers.DefaultRouter()
 router.register('tasks', TaskViewSet)
@@ -13,6 +13,7 @@ router.register('my_application', MyApplicationViewSet)
 
 urlpatterns = [
     path('myself/', ManageUserView.as_view(), name='myself'),
+    path('update_myself/', MyselfUpdateAPIView.as_view(), name='update_myself'),
     path('team_and_tasks/', TeamAndTasks.as_view(), name='team_and_tasks'),
     path('team_and_members/', TeamAndMembers.as_view(), name='team_and_members'),
     path('invitation_create/', InvitationCreateAPIView.as_view(), name='create_invitation'),

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -7,7 +7,7 @@ from users.models import Users
 from .models.task_models import Task
 from .models.team_models import Team
 from .models.application_models import ApplicationToTeam
-from .serializers.serializers import MyselfSerializer, UserSerializer, TaskSerializer, TeamSerializer
+from .serializers.serializers import MyselfSerializer, MyselfUpdateSerializer, UserSerializer, TaskSerializer, TeamSerializer
 from .serializers.application_serializers import ApplicationToTeamSerializer, ApplicationToTeamCreateSerializer
 from .serializers.invitation_create_serializer import InvitationCreateSerializer
 from .ownpermissions import ProfilePermission
@@ -20,6 +20,14 @@ class UserViewSet(mixins.CreateModelMixin, mixins.UpdateModelMixin, mixins.Destr
 
 class ManageUserView(generics.RetrieveUpdateAPIView):
     serializer_class = MyselfSerializer
+    authentication_classes = (JWTAuthentication,)
+    permission_classes = (IsAuthenticated,)
+    
+    def get_object(self):
+        return self.request.user
+
+class MyselfUpdateAPIView(generics.RetrieveUpdateAPIView):
+    serializer_class = MyselfUpdateSerializer
     authentication_classes = (JWTAuthentication,)
     permission_classes = (IsAuthenticated,)
     

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "react-redux": "^7.2.3",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.2",
+    "redux-thunk": "^2.3.0",
     "typescript": "^4.1.2",
     "web-vitals": "^1.0.1"
   },

--- a/frontend/src/constants/constants.ts
+++ b/frontend/src/constants/constants.ts
@@ -1,0 +1,3 @@
+import { apiConfig } from 'commons/apiConfig';
+
+export const baseUrl = apiConfig.apiUrl;

--- a/frontend/src/pages/Teams.tsx
+++ b/frontend/src/pages/Teams.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { useCookies } from 'react-cookie';
 import axios from 'axios';
 import { apiConfig } from 'commons/apiConfig';
+import { useAppSelector, useAppDispatch } from 'app/hooks';
+import { getMyself } from 'slices/user/userSlice';
 import Auth from 'components/Auth';
 import Title from 'components/Title';
 import TextBox from 'components/TextBox';
@@ -44,6 +46,8 @@ const Teams: React.FC = () => {
   const [newTeamName, setNewTeamName] = React.useState<string>('');
   const [cookie] = useCookies();
   const baseUrl = apiConfig.apiUrl;
+  const user = useAppSelector((state) => state.user);
+  const dispatch = useAppDispatch();
 
   React.useEffect(() => {
     axios
@@ -88,8 +92,39 @@ const Teams: React.FC = () => {
       });
   }, [baseUrl, cookie]);
 
+  React.useEffect(() => {
+    dispatch(getMyself(cookie.calendarJWT));
+  }, [cookie.calendarJWT, dispatch]);
+
   const createNewTeam = async () => {
-    console.log('create new team');
+    const res = await axios.post(
+      `${baseUrl}teams/`,
+      {
+        team_name: newTeamName,
+      },
+      {
+        headers: {
+          Authorization: `JWT ${cookie.calendarJWT}`,
+        },
+      }
+    );
+
+    await axios.put(
+      `${baseUrl}update_myself/`,
+      {
+        id: user.id,
+        username: user.username,
+        email: user.email,
+        team_of_affiliation: res.data.id,
+      },
+      {
+        headers: {
+          Authorization: `JWT ${cookie.calendarJWT}`,
+        },
+      }
+    );
+    dispatch(getMyself(cookie.calendarJWT));
+    setTeam(res.data);
   };
 
   if (loading) {

--- a/frontend/src/pages/Teams.tsx
+++ b/frontend/src/pages/Teams.tsx
@@ -44,6 +44,9 @@ const Teams: React.FC = () => {
     null
   );
   const [newTeamName, setNewTeamName] = React.useState<string>('');
+  const [wasCreateNewTeam, setWasCreateNewTeam] = React.useState<boolean>(
+    false
+  );
   const [cookie] = useCookies();
   const baseUrl = apiConfig.apiUrl;
   const user = useAppSelector((state) => state.user);
@@ -125,6 +128,7 @@ const Teams: React.FC = () => {
     );
     dispatch(getMyself(cookie.calendarJWT));
     setTeam(res.data);
+    setWasCreateNewTeam(true);
   };
 
   if (loading) {
@@ -152,6 +156,7 @@ const Teams: React.FC = () => {
     <Auth>
       <Title title="Team" />
       <h3>所属チーム</h3>
+      {wasCreateNewTeam && <p>チームを作成しました</p>}
       <p>{team.team_name}</p>
       <h3>招待</h3>
       <InvitationForm />

--- a/frontend/src/pages/Teams.tsx
+++ b/frontend/src/pages/Teams.tsx
@@ -4,9 +4,11 @@ import axios from 'axios';
 import { apiConfig } from 'commons/apiConfig';
 import Auth from 'components/Auth';
 import Title from 'components/Title';
+import TextBox from 'components/TextBox';
 import MembersList from 'components/Teams/MembersList';
 import InvitationForm from 'components/Teams/InvitationForm';
 import InvitationList from 'components/Teams/InvitationList';
+import Button from 'components/utils/button/Button';
 import './Teams.css';
 
 type Team = {
@@ -39,6 +41,7 @@ const Teams: React.FC = () => {
   const [applicants, setApplicants] = React.useState<Application[] | null>(
     null
   );
+  const [newTeamName, setNewTeamName] = React.useState<string>('');
   const [cookie] = useCookies();
   const baseUrl = apiConfig.apiUrl;
 
@@ -85,6 +88,10 @@ const Teams: React.FC = () => {
       });
   }, [baseUrl, cookie]);
 
+  const createNewTeam = async () => {
+    console.log('create new team');
+  };
+
   if (loading) {
     return (
       <Auth>
@@ -100,6 +107,8 @@ const Teams: React.FC = () => {
         <Title title="Team" />
         <h3>チームに所属していません</h3>
         {myApplication && <p>招待あり</p>}
+        <TextBox value={newTeamName} setValueFunction={setNewTeamName} />
+        <Button text="作成" onClickFunction={createNewTeam} />
       </Auth>
     );
   }

--- a/frontend/src/slices/user/userSlice.ts
+++ b/frontend/src/slices/user/userSlice.ts
@@ -1,18 +1,40 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from 'axios';
+import { baseUrl } from 'constants/constants';
+
+export const getMyself = createAsyncThunk('user/get', async (token: string) => {
+  const res = await axios.get(`${baseUrl}myself/`, {
+    headers: {
+      Authorization: `JWT ${token}`,
+    },
+  });
+  return res.data;
+});
+
+type Team = {
+  id: string;
+  teamName: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type User = {
+  id: string;
+  username: string;
+  email: string;
+  team_of_affiliation: Team | null;
+};
+
+const initialState: User = {
+  id: '',
+  username: '',
+  email: '',
+  team_of_affiliation: null,
+};
 
 export const userSlice = createSlice({
   name: 'user',
-  initialState: {
-    id: '',
-    username: '',
-    email: '',
-    teamOfAffiliation: {
-      id: '',
-      teamName: '',
-      createdAt: '',
-      updatedAt: '',
-    },
-  },
+  initialState,
   reducers: {
     setMyself: (state, action) => {
       state = action.payload;
@@ -22,7 +44,7 @@ export const userSlice = createSlice({
         id: '',
         username: '',
         email: '',
-        teamOfAffiliation: {
+        team_of_affiliation: {
           id: '',
           teamName: '',
           createdAt: '',
@@ -30,6 +52,14 @@ export const userSlice = createSlice({
         },
       };
     },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(getMyself.fulfilled, (state, action) => {
+      return {
+        ...state,
+        ...action.payload,
+      };
+    });
   },
 });
 


### PR DESCRIPTION
# 概要
チームに所属していない場合にチームを新規作成できるようにした

# 内容
- チーム作成用のエンドポイントの`update_myself`を作成
- reduxでログインユーザー情報を取得する非同期関数の`getMyself`を作成
- Team画面で描画時に`getMyself`を呼ぶ
- チーム作成後かどうかの状態を作成
- チーム作成後は通知文言を表示
