### PR TITLE
タスク画面の雛形を作成

### DIFF
--- a/backend/api/serializers/serializers.py
+++ b/backend/api/serializers/serializers.py
@@ -19,7 +19,16 @@ class TaskSerializer(serializers.ModelSerializer):
     
     class Meta:
         model = Task
-        fields = ('id', 'title', 'created_at', 'updated_at')
+        fields = (
+            'id',
+            'title',
+            'team_in_charge',
+            'status',
+            'start_date',
+            'end_date',
+            'created_at',
+            'updated_at'
+        )
     
     def create(self, validated_data):
         user = self.context['request'].user

--- a/frontend/src/components/Teams/InvitationList.module.scss
+++ b/frontend/src/components/Teams/InvitationList.module.scss
@@ -1,6 +1,12 @@
-table,
-td,
-tr {
+.table {
+  border: 2px #808080 solid;
+}
+
+.td {
+  border: 2px #808080 solid;
+}
+
+.tr {
   border: 2px #808080 solid;
 }
 

--- a/frontend/src/components/Teams/InvitationList.tsx
+++ b/frontend/src/components/Teams/InvitationList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useCookies } from 'react-cookie';
 import axios from 'axios';
 import { apiConfig } from 'commons/apiConfig';
-import './InvitationList.scss';
+import styles from './InvitationList.module.scss';
 
 type User = {
   id: number;
@@ -41,9 +41,9 @@ const InvitationList: React.FC<Props> = React.memo(({ invitations }) => {
   const usersList = invitations.map((invitation) => {
     return (
       <tr key={invitation.id}>
-        <td>{invitation.applicant.username}</td>
-        <td>{invitation.applicant.email}</td>
-        <td>
+        <td className={styles.td}>{invitation.applicant.username}</td>
+        <td className={styles.td}>{invitation.applicant.email}</td>
+        <td className={styles.td}>
           <button onClick={() => deleteInvitation(invitation.id)}>取消</button>
         </td>
       </tr>
@@ -53,9 +53,9 @@ const InvitationList: React.FC<Props> = React.memo(({ invitations }) => {
   return (
     <div className="invitation_table">
       {isDelete && <p>招待を取り消しました</p>}
-      <table>
+      <table className={styles.table}>
         <thead>
-          <tr>
+          <tr className={styles.tr}>
             <th>ユーザー名</th>
             <th>メールアドレス</th>
             <th></th>

--- a/frontend/src/components/tasks/TaskRow.module.scss
+++ b/frontend/src/components/tasks/TaskRow.module.scss
@@ -1,0 +1,16 @@
+.tr {
+  border-bottom: solid 1px #eee;
+  cursor: pointer;
+  text-align: center;
+  width: 25%;
+  padding: 15px 0;
+  .td {
+    text-align: center;
+    width: 25%;
+    padding: 15px 0;
+  }
+}
+
+.tr:hover {
+  background-color: #d4f0fd;
+}

--- a/frontend/src/components/tasks/TaskRow.test.tsx
+++ b/frontend/src/components/tasks/TaskRow.test.tsx
@@ -7,12 +7,9 @@ describe('Task Row', () => {
     const task = {
       id: 0,
       title: 'Example Task',
-      team_in_charge: 0,
       status: 'planning',
       start_date: '2021-04-16',
       end_date: '2021-04-20',
-      created_at: '2021-04-16 21:52',
-      updated_at: '2021-04-16 21:52',
     };
     render(<TaskRow {...task} />);
     expect(screen.getByText('Example Task')).toBeTruthy();

--- a/frontend/src/components/tasks/TaskRow.test.tsx
+++ b/frontend/src/components/tasks/TaskRow.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import TaskRow from 'components/tasks/TaskRow';
+
+describe('Task Row', () => {
+  it('Should display task title', () => {
+    const task = {
+      id: 0,
+      title: 'Example Task',
+      team_in_charge: 0,
+      status: 'planning',
+      start_date: '2021-04-16',
+      end_date: '2021-04-20',
+      created_at: '2021-04-16 21:52',
+      updated_at: '2021-04-16 21:52',
+    };
+    render(<TaskRow {...task} />);
+    expect(screen.getByText('Example Task')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/tasks/TaskRow.test.tsx
+++ b/frontend/src/components/tasks/TaskRow.test.tsx
@@ -11,7 +11,13 @@ describe('Task Row', () => {
       start_date: '2021-04-16',
       end_date: '2021-04-20',
     };
-    render(<TaskRow {...task} />);
+    render(
+      <table>
+        <tbody>
+          <TaskRow {...task} />
+        </tbody>
+      </table>
+    );
     expect(screen.getByText('Example Task')).toBeTruthy();
   });
 });

--- a/frontend/src/components/tasks/TaskRow.tsx
+++ b/frontend/src/components/tasks/TaskRow.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import styles from 'components/tasks/TaskRow.module.scss';
 
 interface TaskProps {
   id: number;
@@ -16,11 +17,11 @@ const TaskRow: React.FC<TaskProps> = ({
   end_date,
 }) => {
   return (
-    <tr key={id}>
-      <td>{title}</td>
-      <td>{status}</td>
-      <td>{start_date}</td>
-      <td>{end_date}</td>
+    <tr key={id} className={styles.tr}>
+      <td className={styles.td}>{title}</td>
+      <td className={styles.td}>{status}</td>
+      <td className={styles.td}>{start_date}</td>
+      <td className={styles.td}>{end_date}</td>
     </tr>
   );
 };

--- a/frontend/src/components/tasks/TaskRow.tsx
+++ b/frontend/src/components/tasks/TaskRow.tsx
@@ -3,26 +3,20 @@ import React from 'react';
 interface TaskProps {
   id: number;
   title: string;
-  team_in_charge: number;
   status: string;
   start_date: string;
   end_date: string;
-  created_at: string;
-  updated_at: string;
 }
 
 const TaskRow: React.FC<TaskProps> = ({
   id,
   title,
-  team_in_charge,
   status,
   start_date,
   end_date,
-  created_at,
-  updated_at,
 }) => {
   return (
-    <tr>
+    <tr key={id}>
       <td>{title}</td>
       <td>{status}</td>
       <td>{start_date}</td>

--- a/frontend/src/components/tasks/TaskRow.tsx
+++ b/frontend/src/components/tasks/TaskRow.tsx
@@ -16,7 +16,7 @@ const TaskRow: React.FC<TaskProps> = ({
   end_date,
 }) => {
   return (
-    <tr key={id}>
+    <tr>
       <td>{title}</td>
       <td>{status}</td>
       <td>{start_date}</td>

--- a/frontend/src/components/tasks/TaskRow.tsx
+++ b/frontend/src/components/tasks/TaskRow.tsx
@@ -16,7 +16,7 @@ const TaskRow: React.FC<TaskProps> = ({
   end_date,
 }) => {
   return (
-    <tr>
+    <tr key={id}>
       <td>{title}</td>
       <td>{status}</td>
       <td>{start_date}</td>

--- a/frontend/src/components/tasks/TaskRow.tsx
+++ b/frontend/src/components/tasks/TaskRow.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface TaskProps {
+  id: number;
+  title: string;
+  team_in_charge: number;
+  status: string;
+  start_date: string;
+  end_date: string;
+  created_at: string;
+  updated_at: string;
+}
+
+const TaskRow: React.FC<TaskProps> = ({
+  id,
+  title,
+  team_in_charge,
+  status,
+  start_date,
+  end_date,
+  created_at,
+  updated_at,
+}) => {
+  return (
+    <tr>
+      <td>{title}</td>
+      <td>{status}</td>
+      <td>{start_date}</td>
+      <td>{end_date}</td>
+    </tr>
+  );
+};
+
+export default TaskRow;

--- a/frontend/src/components/tasks/TaskTable.module.scss
+++ b/frontend/src/components/tasks/TaskTable.module.scss
@@ -1,0 +1,3 @@
+.table {
+  border: none;
+}

--- a/frontend/src/components/tasks/TaskTable.module.scss
+++ b/frontend/src/components/tasks/TaskTable.module.scss
@@ -1,3 +1,30 @@
 .table {
-  border: none;
+  min-width: 700px;
+  margin: 50px auto;
+  border-collapse: collapse;
+  border-spacing: 0;
+
+  .tr {
+    border-bottom: solid 1px #eee;
+    cursor: pointer;
+    text-align: center;
+    width: 25%;
+    padding: 15px 0;
+
+    .th {
+      text-align: center;
+      width: 25%;
+      padding: 15px 0;
+      border-bottom: 1px #000;
+    }
+  }
+
+  .tr:hover {
+    background-color: #d4f0fd;
+  }
+
+  .tbody {
+    border-collapse: collapse;
+    border-bottom: 1px #000;
+  }
 }

--- a/frontend/src/components/tasks/TaskTable.test.tsx
+++ b/frontend/src/components/tasks/TaskTable.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import TaskTable from './TaskTable';
+
+describe('Task Table', () => {
+  it('Should display TaskTable', () => {
+    const tasks = [
+      {
+        id: 0,
+        title: 'Example Task',
+        status: 'planning',
+        start_date: '2021-04-16',
+        end_date: '2021-04-20',
+      },
+      {
+        id: 1,
+        title: 'Example Task2',
+        status: 'dev_ready',
+        start_date: '2020-02-15',
+        end_date: '2020-03-13',
+      },
+      {
+        id: 2,
+        title: 'Example Task3',
+        status: 'developing',
+        start_date: '2021-04-15',
+        end_date: '2021-04-15',
+      },
+    ];
+    render(<TaskTable tasks={tasks} />);
+    expect(screen.getByText('タスク名')).toBeTruthy();
+    expect(screen.getByText('planning')).toBeTruthy();
+    expect(screen.getByText('2021-04-20')).toBeTruthy();
+    expect(screen.getByText('dev_ready')).toBeTruthy();
+    expect(screen.getByText('Example Task3')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/tasks/TaskTable.test.tsx
+++ b/frontend/src/components/tasks/TaskTable.test.tsx
@@ -28,7 +28,10 @@ describe('Task Table', () => {
       },
     ];
     render(<TaskTable tasks={tasks} />);
-    expect(screen.getByText('タスク名')).toBeTruthy();
+    expect(screen.getByText('Title')).toBeTruthy();
+    expect(screen.getByText('Status')).toBeTruthy();
+    expect(screen.getByText('Start')).toBeTruthy();
+    expect(screen.getByText('End')).toBeTruthy();
     expect(screen.getByText('planning')).toBeTruthy();
     expect(screen.getByText('2021-04-20')).toBeTruthy();
     expect(screen.getByText('dev_ready')).toBeTruthy();

--- a/frontend/src/components/tasks/TaskTable.tsx
+++ b/frontend/src/components/tasks/TaskTable.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import TaskRow from 'components/tasks/TaskRow';
+
+interface Task {
+  id: number;
+  title: string;
+  status: string;
+  start_date: string;
+  end_date: string;
+}
+
+interface TasksProps {
+  tasks: Task[];
+}
+
+const TaskTable: React.FC<TasksProps> = ({ tasks }) => {
+  const taskRows = tasks.map((task) => {
+    <tr key={task.id}>
+      <TaskRow {...task} />
+    </tr>;
+  });
+  return (
+    <table>
+      <thead>
+        <th>Title</th>
+        <th>Status</th>
+        <th>Start</th>
+        <th>End</th>
+      </thead>
+      <tbody>{taskRows}</tbody>
+    </table>
+  );
+};
+
+export default TaskTable;

--- a/frontend/src/components/tasks/TaskTable.tsx
+++ b/frontend/src/components/tasks/TaskTable.tsx
@@ -19,14 +19,14 @@ const TaskTable: React.FC<TasksProps> = ({ tasks }) => {
   return (
     <table className={styles.table}>
       <thead>
-        <tr>
-          <th>Title</th>
-          <th>Status</th>
-          <th>Start</th>
-          <th>End</th>
+        <tr className={styles.tr}>
+          <th className={styles.th}>Title</th>
+          <th className={styles.th}>Status</th>
+          <th className={styles.th}>Start</th>
+          <th className={styles.th}>End</th>
         </tr>
       </thead>
-      <tbody>{taskRows}</tbody>
+      <tbody className={styles.tbody}>{taskRows}</tbody>
     </table>
   );
 };

--- a/frontend/src/components/tasks/TaskTable.tsx
+++ b/frontend/src/components/tasks/TaskTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import TaskRow from 'components/tasks/TaskRow';
+import styles from 'components/tasks/TaskTable.module.scss';
 
 interface Task {
   id: number;
@@ -16,7 +17,7 @@ interface TasksProps {
 const TaskTable: React.FC<TasksProps> = ({ tasks }) => {
   const taskRows = tasks.map((task) => <TaskRow {...task} key={task.id} />);
   return (
-    <table>
+    <table className={styles.table}>
       <thead>
         <tr>
           <th>Title</th>

--- a/frontend/src/components/tasks/TaskTable.tsx
+++ b/frontend/src/components/tasks/TaskTable.tsx
@@ -14,18 +14,16 @@ interface TasksProps {
 }
 
 const TaskTable: React.FC<TasksProps> = ({ tasks }) => {
-  const taskRows = tasks.map((task) => {
-    <tr key={task.id}>
-      <TaskRow {...task} />
-    </tr>;
-  });
+  const taskRows = tasks.map((task) => <TaskRow {...task} key={task.id} />);
   return (
     <table>
       <thead>
-        <th>Title</th>
-        <th>Status</th>
-        <th>Start</th>
-        <th>End</th>
+        <tr>
+          <th>Title</th>
+          <th>Status</th>
+          <th>Start</th>
+          <th>End</th>
+        </tr>
       </thead>
       <tbody>{taskRows}</tbody>
     </table>

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -1,11 +1,29 @@
 import React from 'react';
 import Auth from 'components/Auth';
 import Title from 'components/Title';
+import TaskTable from 'components/tasks/TaskTable';
 
 const Tasks: React.FC = () => {
+  const tasks = [
+    {
+      id: 0,
+      title: 'Task1',
+      status: 'planning',
+      start_date: '2021-04-16',
+      end_date: '2021-04-18',
+    },
+    {
+      id: 1,
+      title: 'Task2',
+      status: 'dev_ready',
+      start_date: '2021-04-19',
+      end_date: '2021-05-17',
+    },
+  ];
   return (
     <Auth>
       <Title title="Task" />
+      <TaskTable tasks={tasks} />
     </Auth>
   );
 };


### PR DESCRIPTION
# 概要
タスク画面を作成した

# 内容
- `tasks/`のレスポンスのkeyを修正
- TaskRowコンポーネントを作成
- TaskTableコンポーネントを作成
- スタイルを調整
- InvitationListのscssをmoduleに変更
